### PR TITLE
JSON::Schema for data validation

### DIFF
--- a/lib/ModelSEED/Configuration.schema.json
+++ b/lib/ModelSEED/Configuration.schema.json
@@ -1,0 +1,50 @@
+{
+   "type" : "object",
+   "description" : "Configuration details for the ModelSEED",
+   "properties" : {
+      "error_log" : {
+         "type" : "string",
+         "description" : "Directory where error logs are stored"
+      },
+      "stores" : {         "type" : "array",
+         "description" : "An array of storage configurations",
+         "items" : {
+            "type" : "object",
+            "additionalProperties" : {},
+            "properties" : {
+               "class" : {
+                  "required" : true,
+                  "type" : "string"
+               }
+            }
+         }
+      },
+      "mapping" : {
+         "type" : "string",
+         "description" : "Alias for preferred mapping"
+      },
+      "biochemistry" : {
+         "type" : "string",
+         "description" : "Alias for preferred biochemistry"
+      },
+      "model" : {
+         "type" : "string",
+         "description" : "Alias for preferred model"
+      },
+      "login" : {
+         "type" : "object",
+         "description" : "Authentication information",
+         "properties" : {
+            "password" : {
+               "required" : true,
+               "type" : "string"
+            },
+            "username" : {
+               "required" : true,
+               "type" : "string"
+            }
+         }
+      }
+   },
+   "additionalProperties" : false
+}

--- a/lib/ModelSEED/t/Configuration.t
+++ b/lib/ModelSEED/t/Configuration.t
@@ -4,12 +4,13 @@ use ModelSEED::Configuration;
 use File::Temp qw(tempfile);
 use JSON;
 use Test::More;
+use Test::Exception;
 my $testCount = 0;
 
 my ($fh, $TMPDB) = tempfile();
 my $TESTINI = <<INI;
 {
-    "auth" : {
+    "login" : {
         "username" : "alice",
         "password" : "alice's password"
     },
@@ -35,13 +36,30 @@ INI
     my $data = $j->decode($TESTINI);
     is_deeply($c->config, $data, "JSON should go in correctly");
 
+    # test singleton interface
     TODO: {
         local $TODO = "Singleton destructor not working";
         my $d = ModelSEED::Configuration->instance;
         is_deeply($d, $c, "Should be singleton class");
     };
 
-    $testCount += 3;
+    # test save
+    ok $c->save(), "Save should return correctly";
+    # test save actually updates
+    {
+        $c->config->{login}->{username} = "bob";
+        $c->save();
+        my $d = ModelSEED::Configuration->new({filename => $temp_cfg_file});
+        is_deeply($d->config, $c->config, "Should contain same info");
+        is $d->config->{login}->{username}, "bob", "New instance should get data";
+    }
+    # test exception on invalid data being saved
+    {
+        $c->config->{model} = ["an", "array"];
+        dies_ok( sub { $c->save() }, "Should die when trying to save invalid data");
+    }
+
+    $testCount += 7;
 }
 
 


### PR DESCRIPTION
I've been experimenting with using the json-schema specification for data validation. Theoretically it can do a lot of the work that we're doing in ModelSEED::MS objects for a lot less in terms of cost (so good for the REST api or something).

The current Perl implementation is a bit buggy, but I've already submitted an RT issue and the maintainer has responded, so it's not a dead project! He's already made the change to fix the bug, linked below. Hopefully support will improve over time.
- http://json-schema.org/
- JSON::Schema http://search.cpan.org/~tobyink/JSON-Schema-0.012/lib/JSON/Schema.pm
- https://rt.cpan.org/Public/Bug/Display.html?id=76944
